### PR TITLE
Allow Code to be launched straight from Git Bash

### DIFF
--- a/resources/win32/bin/code.sh
+++ b/resources/win32/bin/code.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export VSCODE_DEV=
+export ATOM_SHELL_INTERNAL_RUN_AS_NODE=1
+
+DIRNAME=$(dirname "$0")
+exec "$DIRNAME/../Code.exe" "$DIRNAME/code.js" "$@"


### PR DESCRIPTION
Fixes #1704. Follows the same logic in [the batch file](https://github.com/Microsoft/vscode/blob/master/resources/win32/bin/code.cmd) to create a wrapper script for the executable and run it.

I've tested this locally on my machine, and it seems to be working well.